### PR TITLE
Fixed dirsearch error

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -49,8 +49,8 @@ curl http://ipinfo.io/$1
 
 
 #------ Tools ------
-dirsearch(){ runs dirsearch and takes host and extension as arguments
-python3 ~/tools/dirsearch/dirsearch.py -u $1 -e $2 -t 50 -b 
+dirsearch(){ #runs dirsearch and takes host and extension as arguments
+sudo python3 ~/tools/dirsearch/dirsearch.py -u $1 -e $2 -t 50 -b 
 }
 
 sqlmap(){


### PR DESCRIPTION
Missing comment sign, added it back to fix the run error during dirsearch.
Fixed permissions error in dirsearch by adding sudo before the command.