### PR TITLE
Use .profile as source for bash configurations

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,5 +1,9 @@
 source ~/.profile
 
+export GOROOT=/usr/local/go
+export GOPATH=$HOME/go
+export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
 #----- AWS -------
 
 s3ls(){

--- a/.bash_profile
+++ b/.bash_profile
@@ -55,7 +55,7 @@ curl http://ipinfo.io/$1
 
 
 #------ Tools ------
-dirsearch(){ runs dirsearch and takes host and extension as arguments
+dirsearch(){ #runs dirsearch and takes host and extension as arguments
 python3 ~/tools/dirsearch/dirsearch.py -u $1 -e $2 -t 50 -b 
 }
 

--- a/.bash_profile
+++ b/.bash_profile
@@ -70,3 +70,8 @@ nc -l -n -vv -p $1 -k
 crtshdirsearch(){ #gets all domains from crtsh, runs httprobe and then dir bruteforcers
 curl -s https://crt.sh/?q\=%.$1\&output\=json | jq -r '.[].name_value' | sed 's/\*\.//g' | sort -u | httprobe -c 50 | grep https | xargs -n1 -I{} python3 ~/tools/dirsearch/dirsearch.py -u {} -e $2 -t 50 -b 
 }
+
+sudomy(){
+cd ~/tools/Sudomy
+sudo ./sudomy -d $1 --no-probe
+}

--- a/.bash_profile
+++ b/.bash_profile
@@ -1,3 +1,5 @@
+source ~/.profile
+
 #----- AWS -------
 
 s3ls(){


### PR DESCRIPTION
By default, the ".profile" file is run as source when bash is run. If there is a ".bash_profile" file then ".profile" file does not run and bash doesn't set its own configurations. This code will solve this problem.